### PR TITLE
Fix className not being passed to the input

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -53,7 +53,7 @@ const Input: React.FC<InputProps> = ({
           'nhsuk-input',
           { [`nhsuk-input--width-${width}`]: width },
           { 'nhsuk-input--error': error },
-          classNames,
+          className,
         )}
         id={id}
         ref={ref}


### PR DESCRIPTION
`classNames` function from `classnames` package is currently being passed to the `className` of input tag.
This PR fixes it so that `className` prop is passed instead, following the pattern present other components.
