### PR TITLE
Turn Input component error message into a live region

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -46,7 +46,9 @@ const Input: React.FC<InputProps> = ({
       ) : null}
       {hint ? <Hint id={id ? `${id}-label` : undefined}>{hint}</Hint> : null}
       {error && typeof error === 'string' ? (
-        <ErrorMessage id={id ? `${id}-error` : undefined}>{error}</ErrorMessage>
+        <ErrorMessage id={id ? `${id}-error` : undefined} aria-live="polite">
+          {error}
+        </ErrorMessage>
       ) : null}
       <input
         className={classNames(

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -47,9 +47,11 @@ const Input: React.FC<InputProps> = ({
         </label>
       ) : null}
       {hint ? <Hint id={id ? `${id}-label` : undefined}>{hint}</Hint> : null}
-      <ErrorMessage id={id ? `${id}-error` : undefined} {...errorMessageProps}>
-        {error}
-      </ErrorMessage>
+      {errorMessageProps && errorMessageProps['aria-live'] !== 'off' ? (
+        <ErrorMessage id={id ? `${id}-error` : undefined} {...errorMessageProps}>
+          {error}
+        </ErrorMessage>
+      ) : null}
       <input
         className={classNames(
           'nhsuk-input',

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -6,6 +6,7 @@ import ErrorMessage from '../error-message';
 
 interface InputProps extends HTMLProps<HTMLInputElement> {
   labelProps?: HTMLProps<HTMLLabelElement>;
+  errorMessageProps?: HTMLProps<HTMLLabelElement>;
   hint?: string;
   error?: boolean | string;
   width?: '2' | '3' | '4' | '5' | '10';
@@ -17,6 +18,7 @@ const Input: React.FC<InputProps> = ({
   id,
   ref,
   labelProps,
+  errorMessageProps,
   hint,
   width,
   error,
@@ -45,11 +47,9 @@ const Input: React.FC<InputProps> = ({
         </label>
       ) : null}
       {hint ? <Hint id={id ? `${id}-label` : undefined}>{hint}</Hint> : null}
-      {error && typeof error === 'string' ? (
-        <ErrorMessage id={id ? `${id}-error` : undefined} aria-live="polite">
-          {error}
-        </ErrorMessage>
-      ) : null}
+      <ErrorMessage id={id ? `${id}-error` : undefined} {...errorMessageProps}>
+        {error}
+      </ErrorMessage>
       <input
         className={classNames(
           'nhsuk-input',
@@ -68,6 +68,9 @@ const Input: React.FC<InputProps> = ({
 
 Input.defaultProps = {
   type: 'text',
+  errorMessageProps: {
+    'aria-live': 'polite',
+  },
 };
 
 export default Input;


### PR DESCRIPTION
Currently the appearance of the error message within the `Input` component is not announced to the screen reader, it is not possible either to add a customised property enhancing accessibility to the error message through the `Input` field (`...rest` of props is spread on the `<input>` tag).

I added `aria-live="polite"` as a suggestion and I would appreciate your feedback, as I imagine that in some cases `role="alert"` would be more adequate, depending on the usecase.