### PR TITLE
Tjc warning callout class name

### DIFF
--- a/src/components/warning-callout/WarningCallout.tsx
+++ b/src/components/warning-callout/WarningCallout.tsx
@@ -12,7 +12,7 @@ const WarningCallout: React.FC<WarningCalloutProps> = ({
   labelProps,
   ...rest
 }) => {
-  const { labelClassName: className, ...restLabelProps } = labelProps || {};
+  const { className: labelClassName, ...restLabelProps } = labelProps || {};
   return (
     <div className={classNames('nhsuk-warning-callout', className)} {...rest}>
       {label ? (
@@ -26,6 +26,6 @@ const WarningCallout: React.FC<WarningCalloutProps> = ({
       {children}
     </div>
   );
-}
+};
 
 export default WarningCallout;

--- a/src/components/warning-callout/WarningCallout.tsx
+++ b/src/components/warning-callout/WarningCallout.tsx
@@ -2,7 +2,7 @@ import React, { HTMLProps } from 'react';
 import classNames from 'classnames';
 
 interface WarningCalloutProps extends HTMLProps<HTMLDivElement> {
-  labelProps: HTMLProps<HTMLHeadingElement>;
+  labelProps?: HTMLProps<HTMLHeadingElement>;
 }
 
 const WarningCallout: React.FC<WarningCalloutProps> = ({
@@ -15,7 +15,7 @@ const WarningCallout: React.FC<WarningCalloutProps> = ({
   <div className={classNames('nhsuk-warning-callout', className)} {...rest}>
     {label ? (
       <h3
-        className={classNames('nhsuk-warning-callout__label', labelProps.className)}
+        className={classNames('nhsuk-warning-callout__label', labelProps?.className)}
         {...labelProps}
       >
         {label}
@@ -24,9 +24,5 @@ const WarningCallout: React.FC<WarningCalloutProps> = ({
     {children}
   </div>
 );
-
-WarningCallout.defaultProps = {
-  labelProps: {},
-};
 
 export default WarningCallout;

--- a/src/components/warning-callout/WarningCallout.tsx
+++ b/src/components/warning-callout/WarningCallout.tsx
@@ -1,16 +1,32 @@
 import React, { HTMLProps } from 'react';
 import classNames from 'classnames';
 
-const WarningCallout: React.FC<HTMLProps<HTMLDivElement>> = ({
+interface WarningCalloutProps extends HTMLProps<HTMLDivElement> {
+  labelProps: HTMLProps<HTMLHeadingElement>;
+}
+
+const WarningCallout: React.FC<WarningCalloutProps> = ({
   className,
   label,
   children,
+  labelProps,
   ...rest
 }) => (
   <div className={classNames('nhsuk-warning-callout', className)} {...rest}>
-    {label ? <h3 className="nhsuk-warning-callout__label">{label}</h3> : null}
+    {label ? (
+      <h3
+        className={classNames('nhsuk-warning-callout__label', labelProps.className)}
+        {...labelProps}
+      >
+        {label}
+      </h3>
+    ) : null}
     {children}
   </div>
 );
+
+WarningCallout.defaultProps = {
+  labelProps: {},
+};
 
 export default WarningCallout;

--- a/src/components/warning-callout/WarningCallout.tsx
+++ b/src/components/warning-callout/WarningCallout.tsx
@@ -7,7 +7,7 @@ const WarningCallout: React.FC<HTMLProps<HTMLDivElement>> = ({
   children,
   ...rest
 }) => (
-  <div className={classNames('nhsuk-warning-callout')} {...rest}>
+  <div className={classNames('nhsuk-warning-callout', className)} {...rest}>
     {label ? <h3 className="nhsuk-warning-callout__label">{label}</h3> : null}
     {children}
   </div>


### PR DESCRIPTION
This adds the `className` prop to the warning callout, and allows for passing of props to it's label.