### PR TITLE
Fix DoDontList heading

### DIFF
--- a/src/components/do-dont-list/DoDontList.tsx
+++ b/src/components/do-dont-list/DoDontList.tsx
@@ -27,7 +27,7 @@ const DoDontList: DoDontList = ({
 }) => (
   <div className={classNames('nhsuk-do-dont-list', className)} {...rest}>
     <HeadingLevel className="nhsuk-do-dont-list__label" headingLevel={headingLevel}>
-      {heading || listType === 'do' ? 'Do' : "Don't"}
+      {heading || (listType === 'do' ? 'Do' : "Don't")}
     </HeadingLevel>
     <ul
       className={classNames(


### PR DESCRIPTION
The `heading` prop in the `DoDontList` component isn't working as intended, it currently is used as part of the conditional ternary statement. This allows the prop to be passed through as intended.