### PR TITLE
Fix DateInput Error Behaviour

### DIFF
--- a/src/components/checkboxes/Checkboxes.tsx
+++ b/src/components/checkboxes/Checkboxes.tsx
@@ -80,7 +80,12 @@ class Checkboxes extends PureComponent<CheckboxesProps, CheckboxesState> {
           hintProps={hintProps}
         />
         <CheckboxContext.Provider value={{ isCheckbox: true, name, getBoxId: this.getBoxId }}>
-          <div className={classNames('nhsuk-checkboxes', className)} id={id} {...rest}>
+          <div
+            className={classNames('nhsuk-checkboxes', className)}
+            id={id}
+            aria-describedby={hint ? `${id}--hint` : undefined}
+            {...rest}
+          >
             {children}
           </div>
         </CheckboxContext.Provider>

--- a/src/components/date-input/__tests__/DateInput.test.tsx
+++ b/src/components/date-input/__tests__/DateInput.test.tsx
@@ -4,7 +4,7 @@ import DateInput from '../DateInput';
 
 describe('DateInput', () => {
   it('matches snapshot', () => {
-    const component = mount(<DateInput />);
+    const component = mount(<DateInput name="testInput" />);
     expect(component).toMatchSnapshot();
     component.unmount();
   });

--- a/src/components/date-input/__tests__/DateInput.test.tsx
+++ b/src/components/date-input/__tests__/DateInput.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import DateInput from '../DateInput';
+
+describe('DateInput', () => {
+  it('matches snapshot', () => {
+    const component = mount(<DateInput />);
+    expect(component).toMatchSnapshot();
+    component.unmount();
+  });
+
+  it('wraps onChange handlers', () => {
+    const onChange = jest.fn();
+    const component = mount(<DateInput name="testInput" onChange={onChange} />);
+    // Day
+    component
+      .find('div.nhsuk-date-input')
+      .simulate('change', { target: { name: 'testInput-day', value: '27' } });
+    expect(component.state('value')).toEqual({
+      day: '27',
+      month: '',
+      year: '',
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0].target.value).toEqual({
+      day: '27',
+      month: '',
+      year: '',
+    });
+
+    // Month
+    component
+      .find('div.nhsuk-date-input')
+      .simulate('change', { target: { name: 'testInput-month', value: '06' } });
+    expect(component.state('value')).toEqual({
+      day: '27',
+      month: '06',
+      year: '',
+    });
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange.mock.calls[0][0].target.value).toEqual({
+      day: '27',
+      month: '06',
+      year: '',
+    });
+
+    // Year
+    component
+      .find('div.nhsuk-date-input')
+      .simulate('change', { target: { name: 'testInput-year', value: '2000' } });
+    expect(component.state('value')).toEqual({
+      day: '27',
+      month: '06',
+      year: '2000',
+    });
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(onChange.mock.calls[0][0].target.value).toEqual({
+      day: '27',
+      month: '06',
+      year: '2000',
+    });
+
+    component.unmount();
+  });
+});

--- a/src/components/date-input/__tests__/__snapshots__/DateInput.test.tsx.snap
+++ b/src/components/date-input/__tests__/__snapshots__/DateInput.test.tsx.snap
@@ -1,10 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DateInput matches snapshot 1`] = `
-<DateInput>
+<DateInput
+  name="testInput"
+>
   <LabelBlock />
   <div
     className="nhsuk-date-input"
+    name="testInput"
     onChange={[Function]}
   >
     <DateInputDay>
@@ -21,15 +24,15 @@ exports[`DateInput matches snapshot 1`] = `
           >
             <label
               className="nhsuk-label nhsuk-date-input__label"
-              htmlFor="dateinput_01p06-day"
+              htmlFor="testInput-day"
             >
               Day
             </label>
             <input
-              aria-label="dateinput_01p06-day input"
+              aria-label="testInput-day input"
               className="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2"
-              id="dateinput_01p06-day"
-              name="dateinput_01p06-day"
+              id="testInput-day"
+              name="testInput-day"
               pattern="[0-9]*"
               type="number"
             />
@@ -51,15 +54,15 @@ exports[`DateInput matches snapshot 1`] = `
           >
             <label
               className="nhsuk-label nhsuk-date-input__label"
-              htmlFor="dateinput_01p06-month"
+              htmlFor="testInput-month"
             >
               Month
             </label>
             <input
-              aria-label="dateinput_01p06-month input"
+              aria-label="testInput-month input"
               className="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2"
-              id="dateinput_01p06-month"
-              name="dateinput_01p06-month"
+              id="testInput-month"
+              name="testInput-month"
               pattern="[0-9]*"
               type="number"
             />
@@ -81,15 +84,15 @@ exports[`DateInput matches snapshot 1`] = `
           >
             <label
               className="nhsuk-label nhsuk-date-input__label"
-              htmlFor="dateinput_01p06-year"
+              htmlFor="testInput-year"
             >
               Year
             </label>
             <input
-              aria-label="dateinput_01p06-year input"
+              aria-label="testInput-year input"
               className="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4"
-              id="dateinput_01p06-year"
-              name="dateinput_01p06-year"
+              id="testInput-year"
+              name="testInput-year"
               pattern="[0-9]*"
               type="number"
             />

--- a/src/components/date-input/__tests__/__snapshots__/DateInput.test.tsx.snap
+++ b/src/components/date-input/__tests__/__snapshots__/DateInput.test.tsx.snap
@@ -1,0 +1,102 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DateInput matches snapshot 1`] = `
+<DateInput>
+  <LabelBlock />
+  <div
+    className="nhsuk-date-input"
+    onChange={[Function]}
+  >
+    <DateInputDay>
+      <DateInputInput
+        dateInputType="Day"
+        pattern="[0-9]*"
+        type="number"
+      >
+        <div
+          className="nhsuk-date-input__item"
+        >
+          <div
+            className="nhsuk-form-group"
+          >
+            <label
+              className="nhsuk-label nhsuk-date-input__label"
+              htmlFor="dateinput_01p06-day"
+            >
+              Day
+            </label>
+            <input
+              aria-label="dateinput_01p06-day input"
+              className="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2"
+              id="dateinput_01p06-day"
+              name="dateinput_01p06-day"
+              pattern="[0-9]*"
+              type="number"
+            />
+          </div>
+        </div>
+      </DateInputInput>
+    </DateInputDay>
+    <DateInputMonth>
+      <DateInputInput
+        dateInputType="Month"
+        pattern="[0-9]*"
+        type="number"
+      >
+        <div
+          className="nhsuk-date-input__item"
+        >
+          <div
+            className="nhsuk-form-group"
+          >
+            <label
+              className="nhsuk-label nhsuk-date-input__label"
+              htmlFor="dateinput_01p06-month"
+            >
+              Month
+            </label>
+            <input
+              aria-label="dateinput_01p06-month input"
+              className="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2"
+              id="dateinput_01p06-month"
+              name="dateinput_01p06-month"
+              pattern="[0-9]*"
+              type="number"
+            />
+          </div>
+        </div>
+      </DateInputInput>
+    </DateInputMonth>
+    <DateInputYear>
+      <DateInputInput
+        dateInputType="Year"
+        pattern="[0-9]*"
+        type="number"
+      >
+        <div
+          className="nhsuk-date-input__item"
+        >
+          <div
+            className="nhsuk-form-group"
+          >
+            <label
+              className="nhsuk-label nhsuk-date-input__label"
+              htmlFor="dateinput_01p06-year"
+            >
+              Year
+            </label>
+            <input
+              aria-label="dateinput_01p06-year input"
+              className="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4"
+              id="dateinput_01p06-year"
+              name="dateinput_01p06-year"
+              pattern="[0-9]*"
+              type="number"
+            />
+          </div>
+        </div>
+      </DateInputInput>
+    </DateInputYear>
+  </div>
+</DateInput>
+`;

--- a/src/components/header/components/NHSLogo.tsx
+++ b/src/components/header/components/NHSLogo.tsx
@@ -27,12 +27,12 @@ const NHSLogo: React.FC<HTMLProps<HTMLAnchorElement>> = ({ className, alt, ...re
           aria-labelledby="nhsuk-logo_title"
         >
           <title id="nhsuk-logo_title">{alt}</title>
-          <path className="nhsuk-logo__background" d="M0 0h40v16H0z"></path>
+          <path className="nhsuk-logo__background" d="M0 0h40v16H0z" />
           <path
             className="nhsuk-logo__text"
             d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"
-          ></path>
-          <img src="https://assets.nhs.uk/images/nhs-logo.png" alt={alt}/>
+          />
+          <img src="https://assets.nhs.uk/images/nhs-logo.png" alt={alt} />
         </svg>
         {serviceName ? <span className="nhsuk-header__service-name">{serviceName}</span> : null}
       </a>
@@ -42,7 +42,7 @@ const NHSLogo: React.FC<HTMLProps<HTMLAnchorElement>> = ({ className, alt, ...re
 
 NHSLogo.defaultProps = {
   'aria-label': 'NHS homepage',
-  'alt': 'NHS Logo',
+  alt: 'NHS Logo',
 };
 
 export default NHSLogo;


### PR DESCRIPTION
Currently, the DateInput component does not report errors back to the Form component. This PR passes back the errors, with the following logic:
- If there is an error specified (true or false) to the root `DateInput` component, this is what it reported (regardless of errors in the `DateInput.Day` components)
- If there is no error specified in the root component, it will check errors reported by the `DateInput.Day` etc. subcomponents.