### PR TITLE
Small alignments with nhsuk-frontend

### DIFF
--- a/src/components/care-card/CareCard.tsx
+++ b/src/components/care-card/CareCard.tsx
@@ -36,6 +36,7 @@ const CareCardHeading: React.FC<CareCardHeadingProps> = ({
   children,
   visuallyHiddenText,
   headingLevel,
+  role,
   ...rest
 }) => {
   const cardType = useContext(CareCardContext);
@@ -46,7 +47,7 @@ const CareCardHeading: React.FC<CareCardHeadingProps> = ({
         headingLevel={headingLevel}
         {...rest}
       >
-        <span role="heading">
+        <span role={role}>
           {visuallyHiddenText !== false ? (
             <span className="nhsuk-u-visually-hidden">
               {visuallyHiddenText || genHiddenText(cardType)}
@@ -58,6 +59,10 @@ const CareCardHeading: React.FC<CareCardHeadingProps> = ({
       <span className="nhsuk-care-card__arrow" aria-hidden="true" />
     </div>
   );
+};
+
+CareCardHeading.defaultProps = {
+  role: 'text',
 };
 
 interface CareCard extends React.FC<CareCardProps> {

--- a/src/components/header/components/Nav.tsx
+++ b/src/components/header/components/Nav.tsx
@@ -25,8 +25,9 @@ const Nav: React.FC<HTMLProps<HTMLDivElement>> = ({
       <Container>
         <p className="nhsuk-header__navigation-title">
           <span>Menu</span>
-          <button className="nhsuk-header__navigation-close" onClick={toggleMenu}>
+          <button className="nhsuk-header__navigation-close" type="button" onClick={toggleMenu}>
             <CloseIcon />
+            <span className="nhsuk-u-visually-hidden">Close menu</span>
           </button>
         </p>
         <ul className="nhsuk-header__navigation-list">{children}</ul>


### PR DESCRIPTION
This fixes a couple of small alignment issues with the NHSUK Frontend repo:
1. The Nav Close button had no text inside of it describing the button.
2. The CareCard heading had a role of `"heading"` set permanently. The role prop has now been moved to the span, with a default value of `text` which is the same as the component in `nhsuk-frontend`.