### PR TITLE
WIP: Allow `Input` component to render child components passed to it

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,8 +1,9 @@
 import React, { HTMLProps } from 'react';
-import classNames from 'classnames';
+
+import { FormElementProps } from '../../util/types/FormTypes';
 import FormGroup from '../../util/FormGroup';
 import { InputWidth } from '../../util/types/NHSUKTypes';
-import { FormElementProps } from '../../util/types/FormTypes';
+import classNames from 'classnames';
 
 interface InputProps extends HTMLProps<HTMLInputElement>, FormElementProps {
   inputRef?: (inputRef: HTMLInputElement | null) => any;
@@ -13,16 +14,19 @@ interface InputProps extends HTMLProps<HTMLInputElement>, FormElementProps {
 const Input: React.FC<InputProps> = props => (
   <FormGroup<InputProps> {...props} inputType="input">
     {({ width, className, error, inputRef, ...rest }) => (
-      <input
-        className={classNames(
-          'nhsuk-input',
-          { [`nhsuk-input--width-${width}`]: width },
-          { 'nhsuk-input--error': error },
-          className,
-        )}
-        ref={inputRef}
-        {...rest}
-      />
+      <>
+        <input
+          className={classNames(
+            'nhsuk-input',
+            { [`nhsuk-input--width-${width}`]: width },
+            { 'nhsuk-input--error': error },
+            className,
+          )}
+          ref={inputRef}
+          {...rest}
+        />
+        {props.children}
+      </>
     )}
   </FormGroup>
 );


### PR DESCRIPTION
@Tomdango as you know from discussions with @SatnamSinghUK we have a requirement to render input boxes with a hyperlink underneath, all inside a form group.  Something like this:

![image](https://user-images.githubusercontent.com/2734580/87326486-b25da000-c52a-11ea-9a38-fef7f93dd523.png)

I had a stab this afternoon at enabling the `Input` component  to take child components.  The usage is something like this:

```
<Input label="Question One" width="10">
    <a href="#">Don't know the Question One?</a>
</Input>
```

It's quick and dirty, but it enables us to hit a deadline this week.  Unfortunately, it also has a number of issues, not least, I'm not sure how accessible it will be.

So, would you accept this contribution as is? 

If no, are you ok with this approach, but would like some changes (like tests?)?, or would you prefer if we went down the route you and @SatnamSinghUK have discussed?  Something more like this:

```
<InputWithLink>
    <InputWithLink.Link href=”/some-location”>Example Text</InputWithLink.Link>
</InputWithLink>
```