### PR TITLE
Add 'prepare' step to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "test:ci": "jest --coverage",
     "test:watch": "jest --watch",
     "lint": "eslint --fix -c .eslintrc.js --ext .ts --ext .tsx src/*.ts src/components/**/*.ts src/util/*.ts",
-    "prebuild": "yarn lint && yarn test --coverage"
+    "prebuild": "yarn lint && yarn test --coverage",
+    "prepare": "yarn build"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This step installs dependencies before the package is packaged and installed via git.

This allows us to reference a branch in package.json, for example:

`"nhsuk-react-components": "git://github.com/FutureNHS/nhsuk-react-components#add-prepare-step"`

https://docs.npmjs.com/cli/v6/using-npm/scripts#prepare-and-prepublish