### PR TITLE
Fix the type of the inputRef to work with input elements.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "test:ci": "jest --coverage",
     "test:watch": "jest --watch",
     "lint": "eslint --fix -c .eslintrc.js --ext .ts --ext .tsx src/*.ts src/components/**/*.ts src/util/*.ts",
-    "prebuild": "yarn lint && yarn test --coverage"
+    "prebuild": "yarn lint && yarn test --coverage",
+    "prepare": "yarn build"
   },
   "files": [
     "dist",

--- a/src/components/radios/components/Radio.tsx
+++ b/src/components/radios/components/Radio.tsx
@@ -11,7 +11,7 @@ export interface RadioProps extends HTMLProps<HTMLInputElement> {
   conditional?: ReactNode;
   forceShowConditional?: boolean;
   conditionalWrapperProps?: HTMLProps<HTMLDivElement>;
-  inputRef?: (inputRef: HTMLElement | null) => any;
+  inputRef?: (inputRef: HTMLInputElement | null) => any;
 }
 
 const Radio: React.FC<RadioProps> = ({


### PR DESCRIPTION
It's currently set to `HTMLElement`, which needs to be `HTMLInputElement` to work.