### PR TITLE
added ref feature to select plus written refhook tests for input

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,11 +1,11 @@
-import React, { HTMLProps } from 'react';
+import React, { HTMLProps, MutableRefObject } from 'react';
 import classNames from 'classnames';
 import FormGroup from '../../util/FormGroup';
 import { InputWidth } from '../../util/types/NHSUKTypes';
 import { FormElementProps } from '../../util/types/FormTypes';
 
 interface InputProps extends HTMLProps<HTMLInputElement>, FormElementProps {
-  inputRef?: (inputRef: HTMLInputElement | null) => any;
+  inputRef?: MutableRefObject<HTMLInputElement | null>;
   width?: InputWidth;
   disableErrorLine?: boolean;
 }

--- a/src/components/input/__tests__/input.test.tsx
+++ b/src/components/input/__tests__/input.test.tsx
@@ -1,0 +1,35 @@
+import Input from '../Input';
+import React from 'react';
+import { shallow } from 'enzyme';
+describe('Input', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+      });
+    const InputComp = ({onHandle}: any) => {
+        const ref = React.useRef(null);
+        const handleClick = () => {
+            if(!ref.current) return;
+            onHandle();
+        };
+
+        return (
+            <Input type='button' onClick={handleClick} inputRef={ref}></Input>
+        )
+    };
+    it('should do nothing if ref does not exist', () => {
+        const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: null });
+        const component = shallow(<InputComp />);
+        console.log(component.debug());
+        component.find('Input').simulate('click');
+        expect(useRefSpy).toBeCalledWith(null);
+    });
+
+    it('should handle click where ref Exists', () => {
+        const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: document.createElement('button') });
+        const mock = jest.fn();
+        const component = shallow(<InputComp onHandle={mock} />);
+        component.find('Input').simulate('click');
+        expect(useRefSpy).toBeCalledWith(null);
+        expect(mock).toBeCalledTimes(1);
+      });
+})

--- a/src/components/input/__tests__/input.test.tsx
+++ b/src/components/input/__tests__/input.test.tsx
@@ -19,7 +19,6 @@ describe('Input', () => {
     it('should do nothing if ref does not exist', () => {
         const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: null });
         const component = shallow(<InputComp />);
-        console.log(component.debug());
         component.find('Input').simulate('click');
         expect(useRefSpy).toBeCalledWith(null);
     });

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -1,19 +1,28 @@
-import React, { HTMLProps } from 'react';
-import classNames from 'classnames';
+import React, { HTMLProps, MutableRefObject } from 'react';
+
 import { FormElementProps } from '../../util/types/FormTypes';
 import FormGroup from '../../util/FormGroup';
+import classNames from 'classnames';
 
-type SelectProps = HTMLProps<HTMLSelectElement> & FormElementProps;
+//  SelectProps = HTMLProps<HTMLSelectElement> & FormElementProps;
+interface ISelectProps extends HTMLProps<HTMLSelectElement>, FormElementProps {
+  selectRef?: MutableRefObject<HTMLSelectElement | null>;
+}
 
-interface ISelect extends React.FC<SelectProps> {
+interface ISelect extends React.FC<ISelectProps> {
   Option: React.FC<HTMLProps<HTMLOptionElement>>;
 }
 
 const Select: ISelect = ({ children, ...rest }) => (
-  <FormGroup<SelectProps> inputType="select" {...rest}>
-    {({ className, error, ...restRenderProps }) => (
+  <FormGroup<ISelectProps> inputType="select" {...rest}>
+    {({ className, error, selectRef, ...restRenderProps }) => (
       <select
-        className={classNames('nhsuk-select', { 'nhsuk-select--error': error }, className)}
+        className={classNames(
+          'nhsuk-select',
+          { 'nhsuk-select--error': error },
+          className,
+        )}
+        ref={selectRef}
         {...restRenderProps}
       >
         {children}

--- a/src/components/select/__tests__/Select.test.tsx
+++ b/src/components/select/__tests__/Select.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Select from "../Select";
+import { shallow } from "enzyme";
+
+describe(`Select`, () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+      });
+    const SelectComp = ({onHandle}: any) => {
+        const ref = React.useRef<HTMLSelectElement | null>(null);
+        const handleClick = () => {
+            if(!ref.current) return;
+            onHandle();
+        };
+
+        return (
+          <Select onClick={handleClick} selectRef={ref} />
+        );
+    };
+    it(`should do nothing if ref does not exist`, () => {
+        const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: null });
+        const component = shallow(<SelectComp />);
+        console.log(component.debug());
+        component.find('Select').simulate('click');
+        expect(useRefSpy).toBeCalledWith(null);
+    });
+})

--- a/src/components/select/__tests__/Select.test.tsx
+++ b/src/components/select/__tests__/Select.test.tsx
@@ -20,7 +20,6 @@ describe(`Select`, () => {
     it(`should do nothing if ref does not exist`, () => {
         const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: null });
         const component = shallow(<SelectComp />);
-        console.log(component.debug());
         component.find('Select').simulate('click');
         expect(useRefSpy).toBeCalledWith(null);
     });

--- a/src/components/select/__tests__/Select.test.tsx
+++ b/src/components/select/__tests__/Select.test.tsx
@@ -17,10 +17,20 @@ describe(`Select`, () => {
           <Select onClick={handleClick} selectRef={ref} />
         );
     };
-    it(`should do nothing if ref does not exist`, () => {
+
+    it(`should do nothing if ref does not Exist`, () => {
         const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: null });
         const component = shallow(<SelectComp />);
         component.find('Select').simulate('click');
         expect(useRefSpy).toBeCalledWith(null);
+    });
+
+    it('should handle DOM events where ref Exists', () => {
+        const useRefSpy = jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: document.createElement('select') });
+        const mock = jest.fn();
+        const component = shallow(<SelectComp onHandle={mock} />);
+        component.find('Select').simulate('click');
+        expect(useRefSpy).toBeCalledWith(null);
+        expect(mock).toBeCalledTimes(1);
     });
 })


### PR DESCRIPTION
Note that the ref is propagated via props, which is an anti-pattern to  forwardRef  … see https://reactjs.org/docs/forwarding-refs.html … however, currently the input component has coerced the ref via props. The change will be breaking, however once we have a plan, the forwardRef pattern may be extended to the rest.

Note also added some tests for the input components.   