### PR TITLE
Added numeric cell type

### DIFF
--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -39,22 +39,36 @@ const TableRow: React.FC<HTMLProps<HTMLTableRowElement>> = ({ className, ...rest
 );
 
 interface TableCellProps extends HTMLProps<HTMLTableCellElement> {
-  header?: boolean | undefined;
+  header?: boolean;
+  isNumeric?: boolean;
 }
 
-const TableCell: React.FC<TableCellProps> = ({ className, header, ...rest }) => {
+const TableCell: React.FC<TableCellProps> = ({ className, header, isNumeric, ...rest }) => {
   const sectionType = useContext(TableSectionContext);
+  const regularHeader = <th className={classNames('nhsuk-table__header', className)} scope="col" {...rest} />;
+  const numericHeader = <th className={classNames('nhsuk-table__header', 'nhsuk-table__header--numeric', className)} scope="col" {...rest} />;
+  const regularCell = <td className={classNames('nhsuk-table__cell', className)} {...rest} />;
+  const numericCell = <td className={classNames('nhsuk-table__cell', 'nhsuk-table__cell--numeric', className)} {...rest} />;
+
   if (header !== undefined) {
     if (header === true) {
-      return <th className={classNames('nhsuk-table__header', className)} scope="col" {...rest} />;
+      if (isNumeric) return numericHeader;
+      return regularHeader;
     }
-    return <td className={classNames('nhsuk-table__cell', className)} {...rest} />;
+    if (isNumeric) {
+      return numericCell;
+    }
+    return regularCell;
   }
   if (sectionType === TableSectionTypes.HEAD) {
-    return <th className={classNames('nhsuk-table__header', className)} scope="col" {...rest} />;
+    if (isNumeric) return numericHeader;
+    return regularHeader;
   }
   if (sectionType === TableSectionTypes.BODY) {
-    return <td className={classNames('nhsuk-table__cell', className)} {...rest} />;
+    if (isNumeric) {
+      return numericCell;
+    }
+    return regularCell;
   }
   if (isDev()) {
     console.warn(

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -43,39 +43,33 @@ interface TableCellProps extends HTMLProps<HTMLTableCellElement> {
   isNumeric?: boolean;
 }
 
-const TableCell: React.FC<TableCellProps> = ({ className, header, isNumeric, ...rest }) => {
+const TableCell: React.FC<TableCellProps> = ({ className, header: isHeader, isNumeric, ...rest }) => {
   const sectionType = useContext(TableSectionContext);
   const regularHeader = <th className={classNames('nhsuk-table__header', className)} scope="col" {...rest} />;
   const numericHeader = <th className={classNames('nhsuk-table__header', 'nhsuk-table__header--numeric', className)} scope="col" {...rest} />;
   const regularCell = <td className={classNames('nhsuk-table__cell', className)} {...rest} />;
   const numericCell = <td className={classNames('nhsuk-table__cell', 'nhsuk-table__cell--numeric', className)} {...rest} />;
+  const cell = isNumeric ? numericCell : regularCell;
+  const header = isNumeric ? numericHeader : regularHeader;
 
-  if (header !== undefined) {
-    if (header === true) {
-      if (isNumeric) return numericHeader;
-      return regularHeader;
+  if (isHeader !== undefined) {
+    if (isHeader === true) {
+      return header;
     }
-    if (isNumeric) {
-      return numericCell;
-    }
-    return regularCell;
+    return cell;
   }
   if (sectionType === TableSectionTypes.HEAD) {
-    if (isNumeric) return numericHeader;
-    return regularHeader;
+    return header;
   }
   if (sectionType === TableSectionTypes.BODY) {
-    if (isNumeric) {
-      return numericCell;
-    }
-    return regularCell;
+    return cell;
   }
   if (isDev()) {
     console.warn(
       'TableCell used outside of TableHead or TableBody elements. Unable to determine section type from context.',
     );
   }
-  return <td className={classNames('nhsuk-table__cell', className)} {...rest} />;
+  return cell;
 };
 
 interface TablePanelProps extends HTMLProps<HTMLDivElement> {

--- a/src/components/table/__tests__/Table.test.tsx
+++ b/src/components/table/__tests__/Table.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Table from '..';
 import { shallow, mount } from 'enzyme';
+import Table from '..';
 
 describe('Table', () => {
   it('matches snapshot', () => {
@@ -23,7 +23,7 @@ describe('Table', () => {
     });
 
     it('renders heading', () => {
-      const element = shallow(<Table.Panel heading="Heading"></Table.Panel>);
+      const element = shallow(<Table.Panel heading="Heading" />);
       expect(
         element
           .find('.nhsuk-table__heading-tab')
@@ -36,7 +36,7 @@ describe('Table', () => {
 
   describe('Table.Head', () => {
     it('matches snapshot', () => {
-      const element = shallow(<Table.Head></Table.Head>);
+      const element = shallow(<Table.Head />);
       expect(element).toMatchSnapshot();
       element.unmount();
     });
@@ -46,7 +46,7 @@ describe('Table', () => {
         <Table>
           <Table.Head>
             <Table.Row>
-              <Table.Cell></Table.Cell>
+              <Table.Cell />
             </Table.Row>
           </Table.Head>
         </Table>,
@@ -59,7 +59,7 @@ describe('Table', () => {
 
   describe('Table.Body', () => {
     it('matches snapshot', () => {
-      const element = shallow(<Table.Body></Table.Body>);
+      const element = shallow(<Table.Body />);
       expect(element).toMatchSnapshot();
       element.unmount();
     });
@@ -69,7 +69,7 @@ describe('Table', () => {
         <Table>
           <Table.Body>
             <Table.Row>
-              <Table.Cell></Table.Cell>
+              <Table.Cell />
             </Table.Row>
           </Table.Body>
         </Table>,
@@ -82,7 +82,7 @@ describe('Table', () => {
 
   describe('Table.Row', () => {
     it('matches snapshot', () => {
-      const element = shallow(<Table.Row></Table.Row>);
+      const element = shallow(<Table.Row />);
       expect(element).toMatchSnapshot();
       element.unmount();
     });
@@ -97,17 +97,36 @@ describe('Table', () => {
     });
 
     it('renders as header when supplied', () => {
-      const element = shallow(<Table.Cell header></Table.Cell>);
+      const element = shallow(<Table.Cell header />);
       expect(element.type()).toBe('th');
       expect(element.hasClass('nhsuk-table__header')).toBeTruthy();
       element.unmount();
     });
 
     it('renders normally when header is false', () => {
-      const element = shallow(<Table.Cell header={false}></Table.Cell>);
+      const element = shallow(<Table.Cell header={false} />);
       expect(element.type()).toBe('td');
       expect(element.hasClass('nhsuk-table__header')).toBeFalsy();
       expect(element.hasClass('nhsuk-table__cell')).toBeTruthy();
+      expect(element.hasClass('nhsuk-table__cell--numeric')).toBe(false);
+      element.unmount();
+    });
+
+    it('renders a numeric cell when isNumeric is true', () => {
+      const element = shallow(<Table.Cell header={false} isNumeric />);
+      expect(element.hasClass('nhsuk-table__header')).toBe(false);
+      expect(element.hasClass('nhsuk-table__cell')).toBe(true);
+      expect(element.hasClass('nhsuk-table__cell--numeric')).toBe(true);
+      expect(element.hasClass('nhsuk-table__header--numeric')).toBe(false);
+      element.unmount();
+    });
+
+    it('renders a numeric header when isNumeric is true and header is true', () => {
+      const element = shallow(<Table.Cell header isNumeric />);
+      expect(element.hasClass('nhsuk-table__header')).toBe(true);
+      expect(element.hasClass('nhsuk-table__cell')).toBe(false);
+      expect(element.hasClass('nhsuk-table__header--numeric')).toBe(true);
+      expect(element.hasClass('nhsuk-table__cell--numeric')).toBe(false);
       element.unmount();
     });
   });

--- a/stories/Table.stories.tsx
+++ b/stories/Table.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table } from '../src';
+import { Col, Row, Table } from '../src';
 
 export const StandardTable = () => (
   <Table caption="Skin symptoms and possible causes">
@@ -51,6 +51,35 @@ export const TablePanel = () => (
       </Table.Body>
     </Table>
   </Table.Panel>
+);
+
+export const NumericTable = () => (
+  <Row>
+    <Col width="two-thirds">
+      <Table caption="Number of cases">
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell>Location</Table.Cell>
+            <Table.Cell>Number of cases</Table.Cell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>England</Table.Cell>
+            <Table.Cell isNumeric>4000</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Wales</Table.Cell>
+            <Table.Cell isNumeric>2500</Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>Scotland</Table.Cell>
+            <Table.Cell isNumeric>600</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Col>
+  </Row>
 );
 
 export default {


### PR DESCRIPTION
Added option to use the `nhsuk-table__header--numeric` and  `nhsuk-table__cell--numeric` classes within table cells for right alignment of numbers

<img width="673" alt="image" src="https://user-images.githubusercontent.com/2988301/119138367-b5be9380-ba39-11eb-9e7f-f8b3474b791c.png">
