### PR TITLE
Allowing react 16.8 and higher in the peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
   },
   "peerDependencies": {
     "nhsuk-frontend": ">=4.0.0",
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "dependencies": {
     "classnames": "^2.2.6"


### PR DESCRIPTION
@Tomdango does this look ok to you?  We're using it with react 17 with no problems.