### PR TITLE
Swap input type number with inputmode numeric in date component

### DIFF
--- a/src/components/date-input/__tests__/__snapshots__/DateInput.test.tsx.snap
+++ b/src/components/date-input/__tests__/__snapshots__/DateInput.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`DateInput matches snapshot 1`] = `
             inputMode="numeric"
             inputType="day"
             pattern="[0-9]*"
-            type="number"
+            type="text"
           >
             <div
               className="nhsuk-date-input__item"
@@ -57,7 +57,7 @@ exports[`DateInput matches snapshot 1`] = `
                   name="testInput-day"
                   onChange={[Function]}
                   pattern="[0-9]*"
-                  type="number"
+                  type="text"
                 />
               </div>
             </div>
@@ -68,7 +68,7 @@ exports[`DateInput matches snapshot 1`] = `
             inputMode="numeric"
             inputType="month"
             pattern="[0-9]*"
-            type="number"
+            type="text"
           >
             <div
               className="nhsuk-date-input__item"
@@ -103,7 +103,7 @@ exports[`DateInput matches snapshot 1`] = `
                   name="testInput-month"
                   onChange={[Function]}
                   pattern="[0-9]*"
-                  type="number"
+                  type="text"
                 />
               </div>
             </div>
@@ -114,7 +114,7 @@ exports[`DateInput matches snapshot 1`] = `
             inputMode="numeric"
             inputType="year"
             pattern="[0-9]*"
-            type="number"
+            type="text"
           >
             <div
               className="nhsuk-date-input__item"
@@ -149,7 +149,7 @@ exports[`DateInput matches snapshot 1`] = `
                   name="testInput-year"
                   onChange={[Function]}
                   pattern="[0-9]*"
-                  type="number"
+                  type="text"
                 />
               </div>
             </div>

--- a/src/components/date-input/components/IndividualDateInputs.tsx
+++ b/src/components/date-input/components/IndividualDateInputs.tsx
@@ -96,7 +96,7 @@ const IndividualDateInput: React.FC<IndividualDateInputProps> = ({
 IndividualDateInput.defaultProps = {
   pattern: '[0-9]*',
   inputMode: 'numeric',
-  type: 'number',
+  type: 'text',
 };
 
 export const DayInput: React.FC<Omit<IndividualDateInputProps, 'inputType'>> = (props) => (


### PR DESCRIPTION
Fixes #107 

Implementation in #80 added `inputMode` prop and should have also changed `type` prop from `number` to `text` in line with the [PR in the NHSUK frontend](https://github.com/nhsuk/nhsuk-frontend/pull/666)