### PR TITLE
V2 upgrade docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 - [NHS.UK React Components](#nhsuk-react-components)
   - [Coming from 0.x?](#coming-from-0x)
+  - [Upgrading to 2.0](#upgrading-to-20)
   - [Installation](#installation)
   - [Usage](#usage)
     - [Storybook](#storybook)
@@ -15,6 +16,10 @@ NHS.UK Frontend ported to React
 ## Coming from 0.x?
 
 If you're coming from versions of the library prior to 1.0.0, please give [this doc](/docs/upgrade-to-1.0.md) a brief read, as there a number of changes between 0.x release and the 1.0 release.
+
+## Upgrading to 2.0
+
+If you're upgrading to 2.0, please be aware we have made some breaking changes.  [This doc](/docs/upgrade-to-2.0.md) has the details.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   - [Usage](#usage)
     - [Storybook](#storybook)
   - [Maintainers](#maintainers)
-    - [Preparing Releases](#preparing-releases)
+  - [Preparing Releases](#preparing-releases)
 
 NHS.UK Frontend ported to React
 
@@ -60,8 +60,9 @@ A storybook containing all of the components and their usage can be found [here]
 - Thomas Judd-Cooper ([GitHub](https://github.com/tomdango))
 - Sam Brown ([GitHub](https://github.com/samueldavidbrown))
 - Luke Pearson ([GitHub](https://github.com/lukepearson))
+- Kevin Kuszyk ([GitHub](https://github.com/kevinkuszyk))
 
-### Preparing Releases
+## Preparing Releases
 
 Releases run in CI using github actions.
 

--- a/docs/upgrade-to-2.0.md
+++ b/docs/upgrade-to-2.0.md
@@ -1,11 +1,14 @@
-# Unreleased Changes
+# Upgrading to 2.0
+
+There are some breaking changes you'll need to be aware of when upgrading to v2.  These are mostly related to us upgrading our dependency on [nhsuk-frontend to v4](https://github.com/nhsuk/nhsuk-frontend/blob/master/CHANGELOG.md#400---26-october-2020) which also includes some breaking changes.
+
 ## New Card Component
 
 The new Card component from `nhsuk-frontend` 4 has been added. Check out the storybook for usage examples!
 
-## WarningCallout
+## Warning Callout
 
-### Removal of WarningCallout "label" prop
+### Removal of Warning Callout `label` prop
 
 The WarningCallout `label` prop has been removed, and replaced with `WarningCallout.Label`.
 
@@ -30,7 +33,7 @@ Existing usages of the WarningCallout will need to be replaced with the new synt
 </WarningCallout>
 ```
 
-### Addition of hidden text on the WarningCallout.Label
+### Addition of hidden text on the Warning Callout Label
 
 The `WarningCallout.Label` now has the hidden text `Important: ` before the label content. If this causes an issue in your application, and you would like to change or disable this hidden text you are able to do via the `visuallyHiddenText` prop.
 
@@ -64,3 +67,17 @@ import { Panel, Promo } from "nhsuk-react-components/deprecated";
 ```
 
 A warning is printed to the console in dev environments when using these components, as they are set to be removed in the next major release.
+
+## Date component input type has changed
+
+In line with the upstream nhsuk-frontend, NHS Design Kit and GDS recommendations, we now render the input boxes in the date component as follows:
+
+```html
+<input type="text" inputType="numeric" pattern="[0-9]*">
+```
+
+There is more on this change here:
+
+- [NHSDigital/nhsuk-react-components#108](https://github.com/NHSDigital/nhsuk-react-components/pull/108)
+- [nhsuk/nhsuk-frontend#666](https://github.com/nhsuk/nhsuk-frontend/pull/666)
+- https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-react-components",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0",
   "author": {
     "email": "thomas.judd-cooper1@nhs.net",
     "name": "Thomas Judd-Cooper",


### PR DESCRIPTION
@Tomdango as discussed earlier, this closes #103.  I've moved the WIP changelog bits over to a v2 upgrade guide doc, and bumped the package version to v2.

Once this is merged, I'll cut the v2 and publish it to NPM.

