### PR TITLE
Export button props so it can be imported externally

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,7 +1,7 @@
 import React, { HTMLProps } from 'react';
 import classNames from 'classnames';
 
-interface ButtonProps extends HTMLProps<HTMLButtonElement> {
+export interface ButtonProps extends HTMLProps<HTMLButtonElement> {
   type?: 'button' | 'submit' | 'reset';
   disabled?: boolean;
   secondary?: boolean;


### PR DESCRIPTION
We've developed a `Button` component that so far has a copied `ButtonProps` interface. It'd be a good idea to make this importable so that we can remove remove duplicated code and reuse the same interface.