### PR TITLE
Fix Github pages deployment

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,6 +18,6 @@ jobs:
         run: yarn install
 
       - name: Deploy Storybook
-        run: yarn storybook-to-ghpages --ci
+        run: mkdir -p storybook-build && touch storybook-build/.nojekyll && yarn storybook-to-ghpages --ci --out storybook-build
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
After the storybook v7 upgrade there are build outputs with preceding underscores. This is an issue as [github does not deploy these files](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/), also indicated in [this issue ](https://github.com/storybookjs/storybook/issues/20564#issuecomment-1385326683).

This alters the deployment github action so that it now uses the same output directory so that a `.nojekyll` file can be added there, which bypasses the Jekyll processing on Github Pages which leads to the files with a preceding _ not being deployed

See below for the files attempting to be imported in the built js, and the suspected files in the gh-pages branch which Jekyll is causing not to deploy.

<img width="1724" alt="Screenshot 2023-04-06 at 15 20 42" src="https://user-images.githubusercontent.com/51139521/230406012-571555fe-952f-4f6f-8b87-61978aed4356.png">

<img width="1347" alt="Screenshot 2023-04-06 at 15 21 22" src="https://user-images.githubusercontent.com/51139521/230406188-848db160-f59a-498a-995c-e301de231665.png">


