### PR TITLE
add width and height the NHS logo as per the core library

### DIFF
--- a/src/components/header/components/NHSLogo.tsx
+++ b/src/components/header/components/NHSLogo.tsx
@@ -39,6 +39,8 @@ const NHSLogo: React.FC<NHSLogoNavProps> = ({
           role="img"
           focusable="false"
           viewBox="0 0 40 16"
+          height="40" 
+          width="100"
           aria-labelledby="nhsuk-logo_title"
         >
           <title id="nhsuk-logo_title">{alt}</title>


### PR DESCRIPTION
The NHS logo was missing a width and height attribute causing some validation issues. 

https://nhs-service-manual.slack.com/archives/CDJ29AQCD/p1686240007585369