### PR TITLE
Add missing data module to buttons

### DIFF
--- a/src/components/form-elements/button/Button.tsx
+++ b/src/components/form-elements/button/Button.tsx
@@ -36,6 +36,7 @@ export const Button: FC<ButtonProps> = ({
     disabled={disabled}
     aria-disabled={disabled ? 'true' : 'false'}
     type={type}
+    data-module='nhsuk-button'
     {...rest}
   />
 );
@@ -61,6 +62,7 @@ export const ButtonLink: FC<ButtonLinkProps> = ({
     role={role}
     aria-disabled={disabled ? 'true' : 'false'}
     draggable={draggable}
+    data-module='nhsuk-button'
     {...rest}
   >
     {children}

--- a/src/components/form-elements/button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/form-elements/button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Button disabled matches snapshot: DisabledButton 1`] = `
   <button
     aria-disabled="true"
     class="nhsuk-button nhsuk-button--disabled"
+    data-module="nhsuk-button"
     disabled=""
     type="submit"
   >
@@ -18,6 +19,7 @@ exports[`Button matches snapshot: PlainButton 1`] = `
   <button
     aria-disabled="false"
     class="nhsuk-button"
+    data-module="nhsuk-button"
     type="submit"
   >
     Submit
@@ -30,6 +32,7 @@ exports[`Button reverse matches snapshot: ReverseButton 1`] = `
   <button
     aria-disabled="false"
     class="nhsuk-button nhsuk-button--reverse"
+    data-module="nhsuk-button"
     type="submit"
   >
     Submit
@@ -42,6 +45,7 @@ exports[`Button secondary matches snapshot: SecondaryButton 1`] = `
   <button
     aria-disabled="false"
     class="nhsuk-button nhsuk-button--secondary"
+    data-module="nhsuk-button"
     type="submit"
   >
     Submit
@@ -54,6 +58,7 @@ exports[`ButtonLink button types disabled matches snapshot: DisabledButton 1`] =
   <a
     aria-disabled="true"
     class="nhsuk-button nhsuk-button--disabled"
+    data-module="nhsuk-button"
     draggable="false"
     href="/"
     role="button"
@@ -68,6 +73,7 @@ exports[`ButtonLink button types reverse matches snapshot: ReverseButton 1`] = `
   <a
     aria-disabled="false"
     class="nhsuk-button nhsuk-button--reverse"
+    data-module="nhsuk-button"
     draggable="false"
     href="/"
     role="button"
@@ -82,6 +88,7 @@ exports[`ButtonLink button types secondary matches snapshot: SecondaryButton 1`]
   <a
     aria-disabled="false"
     class="nhsuk-button nhsuk-button--secondary"
+    data-module="nhsuk-button"
     draggable="false"
     href="/"
     role="button"
@@ -96,6 +103,7 @@ exports[`ButtonLink matches snapshot: PlainButton 1`] = `
   <a
     aria-disabled="false"
     class="nhsuk-button"
+    data-module="nhsuk-button"
     draggable="false"
     href="/"
     role="button"


### PR DESCRIPTION
All buttons should have `data-module="nhsuk-button"` applied to them. This is used by the nhs frontend library js - eg to shim certain behaviours for AT.

Fixes #218 