### PR TITLE
Add visually hidden text to summary list examples

### DIFF
--- a/stories/Content Presentation/SummaryList.stories.tsx
+++ b/stories/Content Presentation/SummaryList.stories.tsx
@@ -29,14 +29,18 @@ export const Standard: Story = {
         <SummaryList.Key>Name</SummaryList.Key>
         <SummaryList.Value>Sarah Philips</SummaryList.Value>
         <SummaryList.Actions>
-          <a href="stories#">Change</a>
+          <a href="#">
+            Change<span class="nhsuk-u-visually-hidden"> name</span>
+          </a>
         </SummaryList.Actions>
       </SummaryList.Row>
       <SummaryList.Row>
         <SummaryList.Key>Date of birth</SummaryList.Key>
         <SummaryList.Value>5 January 1978</SummaryList.Value>
         <SummaryList.Actions>
-          <a href="stories#">Change</a>
+          <a href="#">
+            Change<span class="nhsuk-u-visually-hidden"> date of birth</span>
+          </a>
         </SummaryList.Actions>
       </SummaryList.Row>
       <SummaryList.Row>
@@ -49,7 +53,9 @@ export const Standard: Story = {
           SE23 6FH
         </SummaryList.Value>
         <SummaryList.Actions>
-          <a href="stories#">Change</a>
+          <a href="#">
+            Change<span class="nhsuk-u-visually-hidden"> contact information</span>
+          </a>
         </SummaryList.Actions>
       </SummaryList.Row>
       <SummaryList.Row>
@@ -59,11 +65,20 @@ export const Standard: Story = {
           <BodyText>sarah.phillips@example.com</BodyText>
         </SummaryList.Value>
         <SummaryList.Actions>
-          <a href="stories#">Change</a>
+          <a href="#">
+            Change<span class="nhsuk-u-visually-hidden"> contact details</span>
+          </a>
         </SummaryList.Actions>
       </SummaryList.Row>
     </SummaryList>
   ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Change links must include visually hidden text. This means a screen reader user will hear a meaningful action, like "Change name" or "Change date of birth".'
+      }
+    }
+  }
 };
 
 export const SummaryListWithoutActions: Story = {

--- a/stories/Content Presentation/SummaryList.stories.tsx
+++ b/stories/Content Presentation/SummaryList.stories.tsx
@@ -14,7 +14,7 @@ import { Meta, StoryObj } from '@storybook/react';
  * ```jsx
  *  <a href="#">
  *   Change
- *   <span class="nhsuk-u-visually-hidden">
+ *   <span className="nhsuk-u-visually-hidden">
  *     {' '}name
  *   </span>
  * </a>
@@ -51,7 +51,7 @@ export const Standard: Story = {
         <SummaryList.Value>Sarah Philips</SummaryList.Value>
         <SummaryList.Actions>
           <a href="#">
-            Change<span class="nhsuk-u-visually-hidden"> name</span>
+            Change<span className="nhsuk-u-visually-hidden"> name</span>
           </a>
         </SummaryList.Actions>
       </SummaryList.Row>
@@ -60,7 +60,7 @@ export const Standard: Story = {
         <SummaryList.Value>5 January 1978</SummaryList.Value>
         <SummaryList.Actions>
           <a href="#">
-            Change<span class="nhsuk-u-visually-hidden"> date of birth</span>
+            Change<span className="nhsuk-u-visually-hidden"> date of birth</span>
           </a>
         </SummaryList.Actions>
       </SummaryList.Row>
@@ -75,7 +75,7 @@ export const Standard: Story = {
         </SummaryList.Value>
         <SummaryList.Actions>
           <a href="#">
-            Change<span class="nhsuk-u-visually-hidden"> contact information</span>
+            Change<span className="nhsuk-u-visually-hidden"> contact information</span>
           </a>
         </SummaryList.Actions>
       </SummaryList.Row>
@@ -87,7 +87,7 @@ export const Standard: Story = {
         </SummaryList.Value>
         <SummaryList.Actions>
           <a href="#">
-            Change<span class="nhsuk-u-visually-hidden"> contact details</span>
+            Change<span className="nhsuk-u-visually-hidden"> contact details</span>
           </a>
         </SummaryList.Actions>
       </SummaryList.Row>

--- a/stories/Content Presentation/SummaryList.stories.tsx
+++ b/stories/Content Presentation/SummaryList.stories.tsx
@@ -3,6 +3,25 @@ import React from 'react';
 import { SummaryList, BodyText } from '../../src';
 import { Meta, StoryObj } from '@storybook/react';
 
+
+/**
+ * ## Implementation notes
+ *
+ * When providing action links, you must include visually hidden text. This means a screen reader user will hear a meaningful action, like "Change name" or "Change date of birth".'
+ * 
+ * Example of an action link:
+ * 
+ * ```jsx
+ *  <a href="#">
+ *   Change
+ *   <span class="nhsuk-u-visually-hidden">
+ *     {' '}name
+ *   </span>
+ * </a>
+ * ```
+ */
+
+
 const meta: Meta<typeof SummaryList> = {
   title: 'Content Presentation/SummaryList',
   component: SummaryList,
@@ -14,6 +33,8 @@ SummaryList.Row.displayName = 'SummaryList.Row';
 SummaryList.Key.displayName = 'SummaryList.Key';
 SummaryList.Value.displayName = 'SummaryList.Value';
 SummaryList.Actions.displayName = 'SummaryList.Actions';
+
+
 
 export const Standard: Story = {
   argTypes: {
@@ -80,6 +101,8 @@ export const Standard: Story = {
     }
   }
 };
+
+
 
 export const SummaryListWithoutActions: Story = {
   args: { noBorder: false },


### PR DESCRIPTION
Change links in summary lists need visually hidden text so that the links make sense when read in isolation or as a list of links.

In the native design system component you pass arguments for this. Until this is supported, this shows how to manually add the accessible text using the component and updates the docs to mention it needs to be done.

![Screenshot 2024-06-11 at 10 39 56](https://github.com/NHSDigital/nhsuk-react-components/assets/2204224/e6eed877-4ed6-4c68-9821-1b77edfdc106)

Partially fixes #217 