### PR TITLE
Use sentence case for sidebar

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,6 +1,16 @@
 import { addons } from '@storybook/manager-api';
 import nhsTheme from './theme';
+import { startCase, upperFirst } from "lodash";
+
+const sentenceCase = string => {
+  if (typeof string !== 'string') return ''
+  return upperFirst(startCase(string).toLowerCase())
+}
 
 addons.setConfig({
-  theme: nhsTheme,
+  sidebar: {
+    renderLabel: ({ name, type }) =>
+      sentenceCase(name),
+  },
+  theme: nhsTheme
 });


### PR DESCRIPTION
NHS uses sentence case for titles. This is easy to change for the sidebar - though [less so elsewhere](https://github.com/storybookjs/storybook/issues/21395).