### PR TITLE
Remove the aria-labelledby attribute from DateInput fields

### DIFF
--- a/src/components/form-elements/date-input/__tests__/__snapshots__/DateInput.test.tsx.snap
+++ b/src/components/form-elements/date-input/__tests__/__snapshots__/DateInput.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`DateInput matches snapshot 1`] = `
             Day
           </label>
           <input
-            aria-labelledby="testInput-day--label"
             class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2"
             id="testInput-day"
             inputmode="numeric"
@@ -48,7 +47,6 @@ exports[`DateInput matches snapshot 1`] = `
             Month
           </label>
           <input
-            aria-labelledby="testInput-month--label"
             class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-2"
             id="testInput-month"
             inputmode="numeric"
@@ -73,7 +71,6 @@ exports[`DateInput matches snapshot 1`] = `
             Year
           </label>
           <input
-            aria-labelledby="testInput-year--label"
             class="nhsuk-input nhsuk-date-input__input nhsuk-input--width-4"
             id="testInput-year"
             inputmode="numeric"

--- a/src/components/form-elements/date-input/components/IndividualDateInputs.tsx
+++ b/src/components/form-elements/date-input/components/IndividualDateInputs.tsx
@@ -87,7 +87,6 @@ const IndividualDateInput: FC<IndividualDateInputProps> = ({
           value={inputValue}
           defaultValue={inputDefaultValue}
           id={inputID}
-          aria-labelledby={restLabelProps.id || `${inputID}--label`}
           name={inputName}
           onChange={handleChange}
           ref={refCallback}


### PR DESCRIPTION
aria-labelledby is unnecessary because inputs are already semantically linked to their labels