### PR TITLE
Fix chromatic errors on `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           ref: ${{ env.CHROMATIC_BRANCH }}
 
       - name: Storybook deploy
+        if: ${{ env.CHROMATIC_PROJECT_TOKEN }}
         uses: chromaui/action@v13
         with:
           autoAcceptChanges: main


### PR DESCRIPTION
This PR adds a couple of fixes for `main` branch since merging https://github.com/NHSDigital/nhsuk-react-components/pull/276

* Fix [error `✖ Failed to retrieve git information`](https://github.com/NHSDigital/nhsuk-react-components/actions/runs/18349510494/job/52265301420) using `fetch-depth: 0`
* Fix [error `✖ Missing project token`](https://github.com/NHSDigital/nhsuk-react-components/actions/runs/18349596314/job/52265606799) by skipping Dependabot runs