### PR TITLE
Remove duplicate publish checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lint:js": "eslint . --color --max-warnings 0",
     "lint:js:fix": "yarn lint:js --fix",
     "lint:types": "tsc --build tsconfig.json --pretty",
-    "prepublishOnly": "yarn lint && yarn test && yarn storybook --smoke-test"
+    "prepublishOnly": "yarn storybook --smoke-test"
   },
   "devDependencies": {
     "@babel/core": "^7.28.4",


### PR DESCRIPTION
This PR removes the duplicate `yarn lint && yarn test` checks from the `prepublishOnly` script

They're already run via [GitHub Action **release.yml** workflow steps](https://github.com/NHSDigital/nhsuk-react-components/blob/3b2974c1d648dba0b2661dd972a8e302704f76ed/.github/workflows/release.yml#L29-L33)

It fixes the [issue publishing **v6.0.0-beta.1**](https://github.com/NHSDigital/nhsuk-react-components/actions/runs/18350545917) where [JS-DevTools/npm-publish@v1](https://github.com/JS-DevTools/npm-publish/tree/v1/) likely sets `NODE_ENV=production` which overrides the [Babel `@babel/preset-env` modules transform](https://babeljs.io/docs/babel-preset-env#modules) as shown below:

https://github.com/NHSDigital/nhsuk-react-components/blob/3b2974c1d648dba0b2661dd972a8e302704f76ed/babel.config.cjs#L22-L24