### PR TITLE
NHS.UK React components v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS.UK React components
 
-## Unreleased
+## 6.0.1 - 18 May 2026
 
 This is a bug fix release.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-react-components",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "license": "MIT",
   "author": {
     "name": "NHS England"


### PR DESCRIPTION
This PR updates the library to v6.0.1

---

## 6.0.1 - 15 May 2026

This is a bug fix release.

Note: Form components with missing `id` (or `idPrefix`) now fall back to the `name` prop before generating IDs. This helps prevent [hydration mismatch](https://react.dev/link/hydration-mismatch) errors with server-side rendered (SSR) HTML.

### :wrench: **Fixes**

- [#377: Fix radios component with `defaultChecked` inputs and conditional content](https://github.com/NHSDigital/nhsuk-react-components/pull/377)